### PR TITLE
[Prato] : add business logic to fetch specific dishes

### DIFF
--- a/src/main/java/tqs/project/api/controllers/PratoController.java
+++ b/src/main/java/tqs/project/api/controllers/PratoController.java
@@ -1,0 +1,35 @@
+package tqs.project.api.controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import tqs.project.api.models.Prato;
+import tqs.project.api.services.PratoService;
+
+@RestController
+@RequestMapping("/api/dishes")
+@CrossOrigin(origins = "http://localhost:3000")
+public class PratoController {
+    
+    private final PratoService pratoService;
+
+    public PratoController(PratoService pratoService) {
+        this.pratoService = pratoService;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Prato> getPrato(@PathVariable Long id){
+        Prato prato = pratoService.getPrato(id);
+
+        if (prato == null){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        return new ResponseEntity<>(prato, HttpStatus.OK);
+    }
+}

--- a/src/main/java/tqs/project/api/services/PratoService.java
+++ b/src/main/java/tqs/project/api/services/PratoService.java
@@ -1,0 +1,7 @@
+package tqs.project.api.services;
+
+import tqs.project.api.models.Prato;
+
+public interface PratoService {
+    Prato getPrato(Long id);
+}

--- a/src/main/java/tqs/project/api/services/impl/PratoServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/PratoServiceImpl.java
@@ -1,0 +1,22 @@
+package tqs.project.api.services.impl;
+
+import org.springframework.stereotype.Service;
+
+import tqs.project.api.models.Prato;
+import tqs.project.api.repositories.PratoRepository;
+import tqs.project.api.services.PratoService;
+
+@Service
+public class PratoServiceImpl implements PratoService{
+
+    private final PratoRepository pratoRepository;
+
+    public PratoServiceImpl(PratoRepository pratoRepository){
+        this.pratoRepository = pratoRepository;
+    }
+
+    @Override
+    public Prato getPrato(Long id) {
+        return pratoRepository.findById(id).orElse(null);
+    }
+}

--- a/src/test/java/tqs/project/api/controllers/PratoControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/PratoControllerTest.java
@@ -1,0 +1,70 @@
+package tqs.project.api.controllers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import io.restassured.http.ContentType;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import tqs.project.api.models.Prato;
+import tqs.project.api.services.PratoService;
+
+@WebMvcTest(PratoController.class)
+class PratoControllerTest {
+    
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    PratoService service;
+
+    Prato prato = new Prato();
+
+    @BeforeEach
+    void setUp(){
+        prato.setId(1L);
+        prato.setNome("Francesinha");
+    }
+
+    @Test
+    void givenPrato_whenGetPratoById_thenReturnPrato(){
+        when(service.getPrato(1L)).thenReturn(prato);
+
+        RestAssuredMockMvc
+            .given()
+                .mockMvc(mvc)
+                .contentType(ContentType.JSON)
+            .when()
+                .get("/api/dishes/1")
+            .then()
+                .statusCode(HttpStatus.SC_OK)
+                .assertThat()
+                .body("nome", equalTo("Francesinha"));
+
+        verify(service, times(1)).getPrato(1L);
+    }
+
+    @Test 
+    void givenPrato_whenGetPratoByWrongId_thenReturn404(){
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("/api/dishes/1")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+
+        verify(service, times(1)).getPrato(Mockito.any());
+    }
+}

--- a/src/test/java/tqs/project/api/repositories/PratoRepositoryTest.java
+++ b/src/test/java/tqs/project/api/repositories/PratoRepositoryTest.java
@@ -1,0 +1,47 @@
+package tqs.project.api.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import tqs.project.api.models.Prato;
+
+@DataJpaTest
+class PratoRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private PratoRepository repository;
+
+    Prato prato = new Prato();
+
+    @BeforeEach
+    void setUp(){
+        prato.setNome("Francesinha");
+        prato.setPreco(2.5);
+        prato.setStock(10);
+
+        entityManager.persistAndFlush(prato);
+    }
+
+    @Test
+    void givenPrato_whenFindPratoById_thenReturnPrato(){
+        Prato found = repository.findById(prato.getId()).get();
+        
+        assertThat(found.getNome()).isEqualTo("Francesinha");
+    }
+
+    @Test
+    void givenPrato_whenFindPratoByWrongId_thenReturnNull(){
+        Optional<Prato> found = repository.findById(300L);
+        
+        assertThat(found).isEmpty();
+    }
+}

--- a/src/test/java/tqs/project/api/services/PratoServiceTest.java
+++ b/src/test/java/tqs/project/api/services/PratoServiceTest.java
@@ -1,0 +1,61 @@
+package tqs.project.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tqs.project.api.models.Prato;
+import tqs.project.api.repositories.PratoRepository;
+import tqs.project.api.services.impl.PratoServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class PratoServiceTest {
+    
+    @Mock(strictness = Mock.Strictness.LENIENT )
+    private PratoRepository repository;
+
+    @InjectMocks
+    private PratoServiceImpl service;
+
+    Prato prato = new Prato();
+
+    @BeforeEach
+    void setUp(){
+        prato.setId(1L);
+        prato.setNome("Francesinha");
+        prato.setPreco(2.5);
+        prato.setStock(10);
+
+        when(repository.findById(1L)).thenReturn(Optional.of(prato));
+    }
+
+    @Test
+    void whenGetPratoById_thenReturnPrato() {
+        Prato found = service.getPrato(prato.getId()); 
+        
+        verify(repository, times(1)).findById(Mockito.any());
+        assertThat(found.getNome()).isEqualTo("Francesinha");
+    }
+
+    @Test
+    void whenGetPratoByWrongId_thenReturnNull() {
+        Prato found = service.getPrato(300L); 
+        
+        verify(repository, times(1)).findById(Mockito.any());
+        assertThat(found).isNull();
+    }
+}


### PR DESCRIPTION
### Issue

Closes [Endpoint para obter informação de um prato em especifico](https://tqsprojectrestaurant.atlassian.net/jira/software/projects/RMO/boards/2?selectedIssue=RMO-62)

### Reason for this change

We need to be capable of fetching information related to a single dish in the frontend.

### Description of changes

- Created controller with desired endpoint
- Created service with desired logic
- Created tests

### Description of how you validated changes

Tested with `mvn test` and `docker-compose up`

### Checklist
- [X] I have tested my changes locally.

### Aditional Information
N/A