### PR TITLE
[Reserva] : add business logic to fetch booking dates and small fixes

### DIFF
--- a/src/main/java/tqs/project/api/controllers/ReservaController.java
+++ b/src/main/java/tqs/project/api/controllers/ReservaController.java
@@ -1,0 +1,36 @@
+package tqs.project.api.controllers;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import tqs.project.api.services.ReservaService;
+
+@RestController
+@RequestMapping("/api/bookings")
+@CrossOrigin(origins = "http://localhost:3000")
+public class ReservaController {
+
+    private final ReservaService reservaService;
+
+    public ReservaController(ReservaService reservaService){
+        this.reservaService = reservaService;
+    }
+
+    @GetMapping("availableSlots")
+    public ResponseEntity<List<LocalTime>> getTimetable(@RequestParam("date") String date){
+        LocalDate bookingDate = LocalDate.parse(date);
+
+        List<LocalTime> availableSlots = reservaService.getAvailableSlots(bookingDate);
+
+        return new ResponseEntity<>(availableSlots, HttpStatus.OK);
+    }
+}

--- a/src/main/java/tqs/project/api/models/Reserva.java
+++ b/src/main/java/tqs/project/api/models/Reserva.java
@@ -1,6 +1,7 @@
 package tqs.project.api.models;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,4 +37,7 @@ public class Reserva {
 
     @Column(nullable = false)
     private LocalDate dia;
+
+    @Column(nullable = false)
+    private LocalTime hora;
 }

--- a/src/main/java/tqs/project/api/others/ROLES.java
+++ b/src/main/java/tqs/project/api/others/ROLES.java
@@ -1,0 +1,15 @@
+package tqs.project.api.others;
+
+public enum ROLES {
+    USER(0),
+    WAITER(1),
+    KITCHEN(2);
+
+    private final int number;
+
+    ROLES(final int number) {
+        this.number = number;
+    }
+
+    public int getNumber() { return number; }
+}

--- a/src/main/java/tqs/project/api/others/Restaurant.java
+++ b/src/main/java/tqs/project/api/others/Restaurant.java
@@ -17,7 +17,7 @@ public class Restaurant {
     // Restaurant opens at 11:00 and closes at 15:00. It re-opens at 18:00 up until 23:00
     public Restaurant(){
         this.quantidadeMesas = 150L;
-        this.dailySlots = new LinkedList<LocalTime>(Arrays.asList(
+        this.dailySlots = new LinkedList<>(Arrays.asList(
             LocalTime.of(11, 0),
             LocalTime.of(12, 0),
             LocalTime.of(13, 0),

--- a/src/main/java/tqs/project/api/others/Restaurant.java
+++ b/src/main/java/tqs/project/api/others/Restaurant.java
@@ -10,13 +10,13 @@ import lombok.Getter;
 // Opted to not add Setters since it does not fit our purpose here.
 @Getter
 public class Restaurant {
-    private Long quantidadeMesas;
+    private Long totalTables;
 
     private List<LocalTime> dailySlots; 
 
     // Restaurant opens at 11:00 and closes at 15:00. It re-opens at 18:00 up until 23:00
     public Restaurant(){
-        this.quantidadeMesas = 150L;
+        this.totalTables = 10L;
         this.dailySlots = new LinkedList<>(Arrays.asList(
             LocalTime.of(11, 0),
             LocalTime.of(12, 0),

--- a/src/main/java/tqs/project/api/others/Restaurant.java
+++ b/src/main/java/tqs/project/api/others/Restaurant.java
@@ -1,0 +1,32 @@
+package tqs.project.api.others;
+
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import lombok.Getter;
+
+// Opted to not add Setters since it does not fit our purpose here.
+@Getter
+public class Restaurant {
+    private Long quantidadeMesas;
+
+    private List<LocalTime> dailySlots; 
+
+    // Restaurant opens at 11:00 and closes at 15:00. It re-opens at 18:00 up until 23:00
+    public Restaurant(){
+        this.quantidadeMesas = 150L;
+        this.dailySlots = new LinkedList<LocalTime>(Arrays.asList(
+            LocalTime.of(11, 0),
+            LocalTime.of(12, 0),
+            LocalTime.of(13, 0),
+            LocalTime.of(14, 0),
+            LocalTime.of(18, 0),
+            LocalTime.of(19, 0),
+            LocalTime.of(20, 0),
+            LocalTime.of(21, 0),
+            LocalTime.of(22, 0)
+        ));
+    }
+}

--- a/src/main/java/tqs/project/api/repositories/ReservaRepository.java
+++ b/src/main/java/tqs/project/api/repositories/ReservaRepository.java
@@ -1,5 +1,8 @@
 package tqs.project.api.repositories;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +10,5 @@ import tqs.project.api.models.Reserva;
 
 @Repository
 public interface ReservaRepository extends JpaRepository<Reserva, Long>{
-    
+    List<Reserva> findByDia(LocalDate date);
 }

--- a/src/main/java/tqs/project/api/services/ReservaService.java
+++ b/src/main/java/tqs/project/api/services/ReservaService.java
@@ -1,0 +1,9 @@
+package tqs.project.api.services;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public interface ReservaService {
+    List<LocalTime> getAvailableSlots(LocalDate date);
+}

--- a/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
@@ -1,0 +1,37 @@
+package tqs.project.api.services.impl;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import tqs.project.api.models.Reserva;
+import tqs.project.api.others.Restaurant;
+import tqs.project.api.repositories.ReservaRepository;
+import tqs.project.api.services.ReservaService;
+
+@Service
+public class ReservaServiceImpl implements ReservaService{
+    
+    private final ReservaRepository reservaRepository;
+
+    public ReservaServiceImpl(ReservaRepository reservaRepository){
+        this.reservaRepository = reservaRepository;
+    }
+
+    @Override
+    public List<LocalTime> getAvailableSlots(LocalDate date) {
+        Restaurant restaurant = new Restaurant();
+
+        List<LocalTime> availableSlots = restaurant.getDailySlots();
+        List<Reserva> bookings = reservaRepository.findByDia(date);
+
+        for (Reserva reserva : bookings) {
+            availableSlots.remove(reserva.getHora());
+        }
+        
+        return availableSlots;
+    }
+}

--- a/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
@@ -27,11 +27,23 @@ public class ReservaServiceImpl implements ReservaService{
 
         List<LocalTime> availableSlots = restaurant.getDailySlots();
         List<Reserva> bookings = reservaRepository.findByDia(date);
+        List<LocalTime> slotsToRemove = new ArrayList<>();
 
-        for (Reserva reserva : bookings) {
-            availableSlots.remove(reserva.getHora());
+        int usedTables = 0;
+
+        for (LocalTime hour : availableSlots){
+            for (Reserva reserva : bookings) {
+                if (reserva.getHora() == hour){
+                    usedTables += reserva.getQuantidadeMesas();
+                }
+            }
+            if (usedTables == restaurant.getTotalTables()){
+                slotsToRemove.add(hour);
+            }
         }
-        
+
+        availableSlots.removeAll(slotsToRemove);
+
         return availableSlots;
     }
 }

--- a/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
@@ -1,0 +1,54 @@
+package tqs.project.api.controllers;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.CoreMatchers.is;
+
+import java.time.LocalDate;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import io.restassured.http.ContentType;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+import tqs.project.api.others.Restaurant;
+import tqs.project.api.services.ReservaService;
+
+@WebMvcTest(ReservaController.class)
+class ReservaControllerTest {
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    private ReservaService service;
+
+    LocalDate day = LocalDate.parse("2024-01-01");
+    Restaurant restaurant = new Restaurant();
+
+    @BeforeEach
+    void setUp(){
+        when(service.getAvailableSlots(day)).thenReturn(restaurant.getDailySlots());
+    }
+
+    @Test
+    void givenDate_whenGetAvailableSlots_thenReturnSlots(){
+        RestAssuredMockMvc
+            .given()
+                .mockMvc(mvc)
+                .contentType(ContentType.JSON)
+            .when()
+                .get("/api/bookings/availableSlots?date=" + day)
+            .then()
+                .statusCode(HttpStatus.SC_OK)
+                .assertThat()
+                .body("size()", is(restaurant.getDailySlots().size()));
+        
+        verify(service, times(1)).getAvailableSlots(day);
+    }
+}

--- a/src/test/java/tqs/project/api/repositories/ReservaRepositoryTest.java
+++ b/src/test/java/tqs/project/api/repositories/ReservaRepositoryTest.java
@@ -1,0 +1,64 @@
+package tqs.project.api.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import tqs.project.api.models.Reserva;
+import tqs.project.api.models.Utilizador;
+import tqs.project.api.others.ROLES;
+import tqs.project.api.others.STATUS;
+
+@DataJpaTest
+class ReservaRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private ReservaRepository repository;
+
+    LocalDate day = LocalDate.parse("2024-01-01");
+    LocalDate day2 = LocalDate.parse("2024-01-02");
+    Reserva reserva = new Reserva();
+
+
+    @BeforeEach
+    void setUp(){
+        Utilizador utilizador = new Utilizador();
+        utilizador.setEmail("nice-email@gmail.com");
+        utilizador.setPassword("123123123");
+        utilizador.setRole(ROLES.USER.ordinal());
+
+        Reserva reserva = new Reserva();
+        reserva.setUtilizador(utilizador);
+        reserva.setQuantidadeMesas(2);
+        reserva.setStatus(STATUS.COMPLETED.ordinal());
+        reserva.setDia(day2);
+        reserva.setHora(LocalTime.of(11,00));
+
+        entityManager.persist(utilizador);
+        entityManager.persistAndFlush(reserva);
+    }
+
+    @Test
+    void givenNoBookings_whenFindByDay_thenReturnEmpty(){
+        List<Reserva> bookings = repository.findByDia(day);
+
+        assertThat(bookings).hasSize(0);
+    }
+
+    @Test
+    void givenBookings_whenFindByDay_thenBookings(){
+        List<Reserva> bookings = repository.findByDia(day2);
+
+        assertThat(bookings).hasSize(1);
+    }
+}

--- a/src/test/java/tqs/project/api/repositories/ReservaRepositoryTest.java
+++ b/src/test/java/tqs/project/api/repositories/ReservaRepositoryTest.java
@@ -37,7 +37,6 @@ class ReservaRepositoryTest {
         utilizador.setPassword("123123123");
         utilizador.setRole(ROLES.USER.ordinal());
 
-        Reserva reserva = new Reserva();
         reserva.setUtilizador(utilizador);
         reserva.setQuantidadeMesas(2);
         reserva.setStatus(STATUS.COMPLETED.ordinal());
@@ -52,7 +51,7 @@ class ReservaRepositoryTest {
     void givenNoBookings_whenFindByDay_thenReturnEmpty(){
         List<Reserva> bookings = repository.findByDia(day);
 
-        assertThat(bookings).hasSize(0);
+        assertThat(bookings).isEmpty();
     }
 
     @Test

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -86,8 +86,8 @@ class ReservaServiceTest {
 
         assertThat(availableSlots).hasSize(restaurant.getDailySlots().size() - 2);
 
-        assertThat(!availableSlots.contains(LocalTime.of(11,00)));
-        assertThat(!availableSlots.contains(LocalTime.of(22,00)));
+        assertThat(availableSlots).doesNotContain(LocalTime.of(11,00));
+        assertThat(availableSlots).doesNotContain(LocalTime.of(22,00));
 
         verify(repository, times(1)).findByDia(Mockito.any());
     }

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -56,7 +56,7 @@ class ReservaServiceTest {
 
         Reserva reserva = new Reserva();
         reserva.setUtilizador(utilizador);
-        reserva.setQuantidadeMesas(2);
+        reserva.setQuantidadeMesas(10);
         reserva.setStatus(STATUS.COMPLETED.ordinal());
         reserva.setDia(day);
         reserva.setHora(LocalTime.of(11,00));
@@ -66,7 +66,7 @@ class ReservaServiceTest {
         reserva2.setQuantidadeMesas(1);
         reserva2.setStatus(STATUS.COMPLETED.ordinal());
         reserva2.setDia(day);
-        reserva2.setHora(LocalTime.of(22,00));
+        reserva2.setHora(LocalTime.of(12,00));
 
         List<Reserva> someBookings = Arrays.asList(reserva, reserva2);
         when(repository.findByDia(day2)).thenReturn(someBookings);
@@ -85,9 +85,8 @@ class ReservaServiceTest {
         List<LocalTime> availableSlots = service.getAvailableSlots(day2);
 
         assertThat(availableSlots)
-            .hasSize(restaurant.getDailySlots().size() - 2)
-            .doesNotContain(LocalTime.of(11,00))
-            .doesNotContain(LocalTime.of(22,00));
+            .hasSize(restaurant.getDailySlots().size() - 1)
+            .doesNotContain(LocalTime.of(11,00));
 
         verify(repository, times(1)).findByDia(Mockito.any());
     }

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -84,10 +84,10 @@ class ReservaServiceTest {
     void givenSomeReservas_whenGetReservasByDay_thenReturnAvailableReservas(){
         List<LocalTime> availableSlots = service.getAvailableSlots(day2);
 
-        assertThat(availableSlots).hasSize(restaurant.getDailySlots().size() - 2);
-
-        assertThat(availableSlots).doesNotContain(LocalTime.of(11,00));
-        assertThat(availableSlots).doesNotContain(LocalTime.of(22,00));
+        assertThat(availableSlots)
+            .hasSize(restaurant.getDailySlots().size() - 2)
+            .doesNotContain(LocalTime.of(11,00))
+            .doesNotContain(LocalTime.of(22,00));
 
         verify(repository, times(1)).findByDia(Mockito.any());
     }

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -1,0 +1,94 @@
+package tqs.project.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tqs.project.api.others.ROLES;
+import tqs.project.api.others.Restaurant;
+import tqs.project.api.others.STATUS;
+import tqs.project.api.models.Reserva;
+import tqs.project.api.models.Utilizador;
+import tqs.project.api.repositories.ReservaRepository;
+import tqs.project.api.services.impl.ReservaServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class ReservaServiceTest {
+    @Mock(strictness = Mock.Strictness.LENIENT )
+    ReservaRepository repository;
+
+    @InjectMocks
+    ReservaServiceImpl service;
+
+    Restaurant restaurant = new Restaurant();
+    LocalDate day = LocalDate.parse("2024-01-01");
+    LocalDate day2 = LocalDate.parse("2024-01-02");
+
+    @BeforeEach
+    void setUp(){
+        List<Reserva> noBookings = new ArrayList<>();
+        when(repository.findByDia(day)).thenReturn(noBookings);
+
+        Utilizador utilizador = new Utilizador();
+        utilizador.setEmail("nice-email@gmail.com");
+        utilizador.setPassword("123123123");
+        utilizador.setRole(ROLES.USER.ordinal());
+
+        Utilizador utilizador2 = new Utilizador();
+        utilizador2.setEmail("nolimits88@live.com.pt");
+        utilizador2.setPassword("0987654321");
+        utilizador2.setRole(ROLES.USER.ordinal());
+
+        Reserva reserva = new Reserva();
+        reserva.setUtilizador(utilizador);
+        reserva.setQuantidadeMesas(2);
+        reserva.setStatus(STATUS.COMPLETED.ordinal());
+        reserva.setDia(day);
+        reserva.setHora(LocalTime.of(11,00));
+
+        Reserva reserva2 = new Reserva();
+        reserva2.setUtilizador(utilizador2);
+        reserva2.setQuantidadeMesas(1);
+        reserva2.setStatus(STATUS.COMPLETED.ordinal());
+        reserva2.setDia(day);
+        reserva2.setHora(LocalTime.of(22,00));
+
+        List<Reserva> someBookings = Arrays.asList(reserva, reserva2);
+        when(repository.findByDia(day2)).thenReturn(someBookings);
+    }
+
+    @Test
+    void givenNoReservas_whenGetReservasByDay_thenReturnReservas(){
+        List<LocalTime> availableSlots = service.getAvailableSlots(day);
+
+        assertThat(availableSlots).hasSize(restaurant.getDailySlots().size());
+        verify(repository, times(1)).findByDia(Mockito.any());
+    }
+
+    @Test
+    void givenSomeReservas_whenGetReservasByDay_thenReturnAvailableReservas(){
+        List<LocalTime> availableSlots = service.getAvailableSlots(day2);
+
+        assertThat(availableSlots).hasSize(restaurant.getDailySlots().size() - 2);
+
+        assertThat(!availableSlots.contains(LocalTime.of(11,00)));
+        assertThat(!availableSlots.contains(LocalTime.of(22,00)));
+
+        verify(repository, times(1)).findByDia(Mockito.any());
+    }
+}


### PR DESCRIPTION
### Issue

Closes [Endpoint para ver horários](https://tqsprojectrestaurant.atlassian.net/jira/software/projects/RMO/list?selectedIssue=RMO-65)

### Reason for this change

We want to be capable of checking the schedule for the chosen day to choose a timeslot and book it.

### Description of changes

- Created controller with desired endpoint
- Created service with desired logic
- Created tests
- Created new restaurant class to provide easy manipulation
- Created ENUM for roles

### Description of how you validated changes

Tested with `mvn test` and `docker-compose up`

### Checklist
- [X] I have tested my changes locally.

### Aditional Information
N/A