### PR TITLE
[Menu] : add business logic to fetch daily menu

### DIFF
--- a/src/main/java/tqs/project/api/controllers/MenuController.java
+++ b/src/main/java/tqs/project/api/controllers/MenuController.java
@@ -1,0 +1,34 @@
+package tqs.project.api.controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import tqs.project.api.models.Menu;
+import tqs.project.api.services.MenuService;
+
+@RestController
+@RequestMapping("/api/menu")
+@CrossOrigin(origins = "http://localhost:3000")
+public class MenuController {
+
+    private final MenuService menuService;
+
+    public MenuController(MenuService menuService){
+        this.menuService = menuService;
+    }
+
+    @GetMapping
+    public ResponseEntity<Menu> getDailyMenu(){
+        Menu menu = menuService.getDailyMenu();
+
+        if (menu == null){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        return new ResponseEntity<>(menu, HttpStatus.OK);
+    }
+}

--- a/src/main/java/tqs/project/api/initializer/DataInitializer.java
+++ b/src/main/java/tqs/project/api/initializer/DataInitializer.java
@@ -1,6 +1,8 @@
 package tqs.project.api.initializer;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,10 +11,12 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import tqs.project.api.models.Bebida;
+import tqs.project.api.models.Menu;
 import tqs.project.api.models.Pedido;
 import tqs.project.api.models.Prato;
 import tqs.project.api.others.STATUS;
 import tqs.project.api.repositories.BebidaRepository;
+import tqs.project.api.repositories.MenuRepository;
 import tqs.project.api.repositories.PedidoRepository;
 import tqs.project.api.repositories.PratoRepository;
 
@@ -23,18 +27,22 @@ public class DataInitializer implements CommandLineRunner {
     BebidaRepository bebidaRepository;
     PratoRepository pratoRepository;
     PedidoRepository pedidoRepository;
+    MenuRepository menuRepository;
 
     int TOTAL_PEDIDOS = 10;
 
     Bebida[] BEBIDAS = new Bebida[TOTAL_PEDIDOS];
     Prato[] PRATOS = new Prato[TOTAL_PEDIDOS];
     Pedido[] PEDIDOS = new Pedido[TOTAL_PEDIDOS];
+    Menu[] MENUS = new Menu[3];
 
     @Autowired
-    public DataInitializer(BebidaRepository bebidaRepository, PratoRepository pratoRepository, PedidoRepository pedidoRepository){
+    public DataInitializer(BebidaRepository bebidaRepository, PratoRepository pratoRepository, PedidoRepository pedidoRepository,
+                            MenuRepository menuRepository){
         this.bebidaRepository = bebidaRepository;
         this.pratoRepository = pratoRepository;
         this.pedidoRepository = pedidoRepository;
+        this.menuRepository = menuRepository;
     }
 
     public void run(String... args) throws Exception{
@@ -45,6 +53,7 @@ public class DataInitializer implements CommandLineRunner {
         this.loadBebidas();
         this.loadPratos();
         this.loadPedidos();
+        this.loadMenus();
     }
 
     public int getRandomInt(int min, int max) {
@@ -182,4 +191,31 @@ public class DataInitializer implements CommandLineRunner {
             PRATOS[i] = pratoRepository.save(PRATOS[i]);
         }
     }
+
+    private void loadMenus(){
+        MENUS[0] = new Menu();
+
+        MENUS[0].setDia(LocalDate.now());
+        MENUS[0].setPratos(Arrays.asList(PRATOS[0], PRATOS[1], PRATOS[6], PRATOS[9]));
+        MENUS[0].setBebidas(Arrays.asList(BEBIDAS[0], BEBIDAS[1], BEBIDAS[6], BEBIDAS[9]));
+
+        menuRepository.save(MENUS[0]);
+
+        MENUS[1] = new Menu();
+
+        MENUS[1].setDia(LocalDate.now().plusDays(1));
+        MENUS[1].setPratos(Arrays.asList(PRATOS[4], PRATOS[2], PRATOS[6], PRATOS[7]));
+        MENUS[1].setBebidas(Arrays.asList(BEBIDAS[2], BEBIDAS[1], BEBIDAS[4], BEBIDAS[3]));
+
+        menuRepository.save(MENUS[1]);
+
+        MENUS[2] = new Menu();
+
+        MENUS[2].setDia(LocalDate.now().plusDays(2));
+        MENUS[2].setPratos(Arrays.asList(PRATOS[3], PRATOS[8], PRATOS[5], PRATOS[0]));
+        MENUS[2].setBebidas(Arrays.asList(BEBIDAS[7], BEBIDAS[5], BEBIDAS[8], BEBIDAS[9]));
+
+        menuRepository.save(MENUS[2]);
+    }
+
 }

--- a/src/main/java/tqs/project/api/models/Menu.java
+++ b/src/main/java/tqs/project/api/models/Menu.java
@@ -30,6 +30,6 @@ public class Menu {
     @ManyToMany
     private List<Bebida> bebidas;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private LocalDate dia;
 }

--- a/src/main/java/tqs/project/api/repositories/MenuRepository.java
+++ b/src/main/java/tqs/project/api/repositories/MenuRepository.java
@@ -1,5 +1,7 @@
 package tqs.project.api.repositories;
 
+import java.time.LocalDate;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +9,5 @@ import tqs.project.api.models.Menu;
 
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
-    
+    Menu findByDia(LocalDate date);
 }

--- a/src/main/java/tqs/project/api/services/MenuService.java
+++ b/src/main/java/tqs/project/api/services/MenuService.java
@@ -1,0 +1,7 @@
+package tqs.project.api.services;
+
+import tqs.project.api.models.Menu;
+
+public interface MenuService {
+    public Menu getDailyMenu();
+}

--- a/src/main/java/tqs/project/api/services/impl/MenuServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/MenuServiceImpl.java
@@ -1,0 +1,30 @@
+package tqs.project.api.services.impl;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+
+import tqs.project.api.models.Menu;
+import tqs.project.api.repositories.MenuRepository;
+import tqs.project.api.services.MenuService;
+
+@Service
+public class MenuServiceImpl implements MenuService {
+    
+    private final MenuRepository menuRepository;
+
+    public MenuServiceImpl(MenuRepository menuRepository){
+        this.menuRepository = menuRepository;
+    }
+
+    @Override
+    public Menu getDailyMenu() {
+        Menu menu = menuRepository.findByDia(LocalDate.now());
+
+        if (menu == null){
+            return null;
+        }
+
+        return menu;
+    }
+}

--- a/src/test/java/tqs/project/api/controllers/MenuControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/MenuControllerTest.java
@@ -1,0 +1,71 @@
+package tqs.project.api.controllers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import io.restassured.http.ContentType;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+
+import tqs.project.api.models.Menu;
+import tqs.project.api.services.MenuService;
+
+@WebMvcTest(MenuController.class)
+class MenuControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    private MenuService service;
+
+    Menu menu = new Menu();
+    
+    @BeforeEach
+    void setUp(){
+        menu.setDia(LocalDate.now());
+    }
+
+    @Test
+    void givenMenu_whenGetDailyMenu_thenReturnTodaysMenu(){
+        when(service.getDailyMenu()).thenReturn(menu);
+
+        RestAssuredMockMvc
+            .given()
+                .mockMvc(mvc)
+                .contentType(ContentType.JSON)
+            .when()
+                .get("/api/menu")
+            .then()
+                .statusCode(HttpStatus.SC_OK)
+                .assertThat()
+                .body("dia", is(LocalDate.now().toString()));
+
+        verify(service, times(1)).getDailyMenu();
+    }
+
+    @Test
+    void givenNoMenu_whenGetDailyMenu_thenReturn404(){
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("/api/menu")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+
+        verify(service, times(1)).getDailyMenu();
+    }
+}

--- a/src/test/java/tqs/project/api/repositories/MenuRepositoryTest.java
+++ b/src/test/java/tqs/project/api/repositories/MenuRepositoryTest.java
@@ -37,8 +37,8 @@ class MenuRepositoryTest {
 
     @Test
     void givenSetOfMenus_whenFindDailyMenu_thenReturnDailyMenu(){
-        Menu menu = repository.findByDia(LocalDate.now());
+        Menu found = repository.findByDia(LocalDate.now());
 
-        assertThat(menu.getDia()).isEqualTo(LocalDate.now().toString());
+        assertThat(found.getDia()).isEqualTo(LocalDate.now().toString());
     }
 }

--- a/src/test/java/tqs/project/api/repositories/MenuRepositoryTest.java
+++ b/src/test/java/tqs/project/api/repositories/MenuRepositoryTest.java
@@ -1,0 +1,44 @@
+package tqs.project.api.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import tqs.project.api.models.Menu;
+
+@DataJpaTest
+class MenuRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private MenuRepository repository;
+
+    Menu menu = new Menu();
+    Menu menu2 = new Menu();
+    Menu menu3 = new Menu();
+
+    @BeforeEach
+    void setUp(){
+        menu.setDia(LocalDate.now());
+        menu2.setDia(LocalDate.now().plusDays(1));
+        menu3.setDia(LocalDate.now().plusDays(2));
+
+        entityManager.persist(menu);
+        entityManager.persist(menu2);
+        entityManager.persistAndFlush(menu3);
+    }
+
+    @Test
+    void givenSetOfMenus_whenFindDailyMenu_thenReturnDailyMenu(){
+        Menu menu = repository.findByDia(LocalDate.now());
+
+        assertThat(menu.getDia()).isEqualTo(LocalDate.now().toString());
+    }
+}

--- a/src/test/java/tqs/project/api/services/MenuServiceTest.java
+++ b/src/test/java/tqs/project/api/services/MenuServiceTest.java
@@ -1,0 +1,53 @@
+package tqs.project.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tqs.project.api.models.Menu;
+import tqs.project.api.repositories.MenuRepository;
+import tqs.project.api.services.impl.MenuServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class MenuServiceTest {
+    @Mock(strictness = Mock.Strictness.LENIENT )
+    private MenuRepository repository;
+
+    @InjectMocks
+    private MenuServiceImpl service;
+
+    Menu menu = new Menu();
+
+    @BeforeEach
+    void setUp(){
+        menu.setDia(LocalDate.now());
+    }
+
+    @Test
+    void givenMenu_whenGetDailyMenu_thenReturnTodaysMenu(){
+        when(repository.findByDia(LocalDate.now())).thenReturn(menu);
+
+        Menu menu = service.getDailyMenu();
+
+        assertThat(menu.getDia()).isEqualTo(LocalDate.now().toString());
+        verify(repository, times(1)).findByDia(LocalDate.now());
+    }
+
+    @Test
+    void givenNoMenu_whenGetDailyMenu_thenReturnTodaysMenu(){
+        Menu menu = service.getDailyMenu();
+
+        assertThat(menu).isNull();
+        verify(repository, times(1)).findByDia(LocalDate.now());
+    }
+}

--- a/src/test/java/tqs/project/api/services/MenuServiceTest.java
+++ b/src/test/java/tqs/project/api/services/MenuServiceTest.java
@@ -37,17 +37,17 @@ class MenuServiceTest {
     void givenMenu_whenGetDailyMenu_thenReturnTodaysMenu(){
         when(repository.findByDia(LocalDate.now())).thenReturn(menu);
 
-        Menu menu = service.getDailyMenu();
+        Menu found = service.getDailyMenu();
 
-        assertThat(menu.getDia()).isEqualTo(LocalDate.now().toString());
+        assertThat(found.getDia()).isEqualTo(LocalDate.now().toString());
         verify(repository, times(1)).findByDia(LocalDate.now());
     }
 
     @Test
     void givenNoMenu_whenGetDailyMenu_thenReturnTodaysMenu(){
-        Menu menu = service.getDailyMenu();
+        Menu found = service.getDailyMenu();
 
-        assertThat(menu).isNull();
+        assertThat(found).isNull();
         verify(repository, times(1)).findByDia(LocalDate.now());
     }
 }


### PR DESCRIPTION
### Issue

Closes [Endpoint para obter menu do dia](https://tqsprojectrestaurant.atlassian.net/jira/software/projects/RMO/boards/2?selectedIssue=RMO-58)

### Reason for this change

We need a way to fetch information about today's menu.

### Description of changes

- Added new restriction to `day` in the Menu Model (now it requires the day to be UNIQUE)
- Created controller with desired endpoint
- Created service with desired logic
- Created tests
- Added Menus to our data initializer

### Description of how you validated changes

Tested with `mvn test` and `docker-compose up`

### Checklist
- [X] I have tested my changes locally.

### Aditional Information
N/A