### PR TITLE
[Bebida] : add endpoint to get beverages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<version>6.3.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt</artifactId>
 			<version>0.12.5</version>

--- a/src/main/java/tqs/project/api/configuration/JwtAuthenticationFilter.java
+++ b/src/main/java/tqs/project/api/configuration/JwtAuthenticationFilter.java
@@ -18,15 +18,15 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import tqs.project.api.services.JwtService;
-import tqs.project.api.services.UserService;
+import tqs.project.api.services.CustomUserDetailsService;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtService jwtService;
-    private final UserService userService;
+    private final CustomUserDetailsService userService;
 
     @Autowired
-    public JwtAuthenticationFilter(JwtService jwtService,UserService userService){
+    public JwtAuthenticationFilter(JwtService jwtService,CustomUserDetailsService userService){
         this.jwtService = jwtService;
         this.userService = userService;
     }

--- a/src/main/java/tqs/project/api/configuration/SecurityConfig.java
+++ b/src/main/java/tqs/project/api/configuration/SecurityConfig.java
@@ -18,16 +18,16 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import tqs.project.api.others.ROLES;
-import tqs.project.api.services.UserService;
+import tqs.project.api.services.CustomUserDetailsService;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final UserService userService;
+    private final CustomUserDetailsService userService;
 
     @Autowired
-    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,UserService userService){
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter, CustomUserDetailsService userService){
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.userService = userService;
     }

--- a/src/main/java/tqs/project/api/controllers/BebidaController.java
+++ b/src/main/java/tqs/project/api/controllers/BebidaController.java
@@ -1,0 +1,46 @@
+package tqs.project.api.controllers;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import tqs.project.api.models.Bebida;
+import tqs.project.api.models.Prato;
+import tqs.project.api.services.BebidaService;
+
+@RestController
+@Tag(name = "Beverage API")
+@RequestMapping("/api/beverages")
+@CrossOrigin(origins = "http://localhost:3000")
+public class BebidaController {
+    
+    private final BebidaService bebidaService;
+
+    public BebidaController(BebidaService bebidaService){
+        this.bebidaService = bebidaService;
+    }
+
+    @Operation(summary = "Get beverage by ID", description = "Returns beverage object by given ID")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+        @ApiResponse(responseCode = "404", description = "No beverage was found with given ID")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<Bebida> getBebida(@PathVariable Long id){
+        Bebida beverage = bebidaService.getBebida(id);
+
+        if (beverage == null){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        return new ResponseEntity<>(beverage, HttpStatus.OK);
+    }
+}

--- a/src/main/java/tqs/project/api/controllers/ReservaController.java
+++ b/src/main/java/tqs/project/api/controllers/ReservaController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,14 +51,20 @@ public class ReservaController {
         return new ResponseEntity<>(availableSlots, HttpStatus.OK);
     }
 
+
     @Operation(summary = "Post booking on selected date", description = "Returns booked object and confirmation")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201",
                     description = "Successfully created")
     })
     @PostMapping
-    public ResponseEntity<Reserva> createBooking(){
-        Reserva booking = reservaService.createBooking();
+    public ResponseEntity<Reserva> createBooking(@RequestBody Reserva reserva){
+        Reserva booking = reservaService.createBooking(reserva);
+
+        if (booking == null){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
         return new ResponseEntity<>(booking, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/tqs/project/api/controllers/ReservaController.java
+++ b/src/main/java/tqs/project/api/controllers/ReservaController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +19,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import tqs.project.api.models.Reserva;
 import tqs.project.api.services.ReservaService;
 
 @RestController
@@ -46,5 +48,16 @@ public class ReservaController {
         List<LocalTime> availableSlots = reservaService.getAvailableSlots(bookingDate);
 
         return new ResponseEntity<>(availableSlots, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Post booking on selected date", description = "Returns booked object and confirmation")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201",
+                    description = "Successfully created")
+    })
+    @PostMapping
+    public ResponseEntity<Reserva> createBooking(){
+        Reserva booking = reservaService.createBooking();
+        return new ResponseEntity<>(booking, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/tqs/project/api/models/Utilizador.java
+++ b/src/main/java/tqs/project/api/models/Utilizador.java
@@ -7,6 +7,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,8 +33,8 @@ public class Utilizador implements UserDetails{
     private Long id;
 
     @OneToMany
-    @JoinColumn(name = "reserva")
-    private List<Reserva> reserva;
+    @JoinColumn(name = "reservas")
+    private List<Reserva> reservas;
 
     @Column(nullable = false, unique = true)
     private String email;
@@ -44,6 +46,7 @@ public class Utilizador implements UserDetails{
     private ROLES role;
 
     @Override
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(role.name()));
     }

--- a/src/main/java/tqs/project/api/repositories/ReservaRepository.java
+++ b/src/main/java/tqs/project/api/repositories/ReservaRepository.java
@@ -1,6 +1,7 @@
 package tqs.project.api.repositories;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ import tqs.project.api.models.Reserva;
 @Repository
 public interface ReservaRepository extends JpaRepository<Reserva, Long>{
     List<Reserva> findByDia(LocalDate date);
+
+    List<Reserva> findByDiaAndHora(LocalDate date, LocalTime time);
 }

--- a/src/main/java/tqs/project/api/services/BebidaService.java
+++ b/src/main/java/tqs/project/api/services/BebidaService.java
@@ -1,0 +1,7 @@
+package tqs.project.api.services;
+
+import tqs.project.api.models.Bebida;
+
+public interface BebidaService {
+    Bebida getBebida(Long id);
+}

--- a/src/main/java/tqs/project/api/services/CustomUserDetailsService.java
+++ b/src/main/java/tqs/project/api/services/CustomUserDetailsService.java
@@ -1,0 +1,7 @@
+package tqs.project.api.services;
+
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+public interface CustomUserDetailsService {
+    UserDetailsService userDetailsService();
+}

--- a/src/main/java/tqs/project/api/services/ReservaService.java
+++ b/src/main/java/tqs/project/api/services/ReservaService.java
@@ -4,6 +4,10 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
+import tqs.project.api.models.Reserva;
+
 public interface ReservaService {
     List<LocalTime> getAvailableSlots(LocalDate date);
+
+    Reserva createBooking(Reserva reserva);
 }

--- a/src/main/java/tqs/project/api/services/UserService.java
+++ b/src/main/java/tqs/project/api/services/UserService.java
@@ -1,7 +1,5 @@
 package tqs.project.api.services;
 
-import org.springframework.security.core.userdetails.UserDetailsService;
-
 public interface UserService {
-    UserDetailsService userDetailsService();
+    
 }

--- a/src/main/java/tqs/project/api/services/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/AuthenticationServiceImpl.java
@@ -10,7 +10,7 @@ import tqs.project.api.models.Utilizador;
 import tqs.project.api.repositories.UtilizadorRepository;
 import tqs.project.api.services.AuthenticationService;
 import tqs.project.api.services.JwtService;
-import tqs.project.api.services.UserService;
+import tqs.project.api.services.CustomUserDetailsService;
 
 @Service
 public class AuthenticationServiceImpl implements AuthenticationService {
@@ -18,12 +18,12 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     private final AuthenticationManager authenticationManager;
     private final UtilizadorRepository utilizadorRepository;
     private final JwtService jwtService;
-    private final UserService userService;
+    private final CustomUserDetailsService userService;
 
     public AuthenticationServiceImpl(AuthenticationManager authenticationManager, 
                                         UtilizadorRepository utilizadorRepository,
                                         JwtService jwtService,
-                                        UserService userService){
+                                        CustomUserDetailsService userService){
         this.authenticationManager = authenticationManager;
         this.utilizadorRepository = utilizadorRepository;
         this.jwtService = jwtService;

--- a/src/main/java/tqs/project/api/services/impl/BebidaServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/BebidaServiceImpl.java
@@ -1,0 +1,22 @@
+package tqs.project.api.services.impl;
+
+import org.springframework.stereotype.Service;
+
+import tqs.project.api.models.Bebida;
+import tqs.project.api.repositories.BebidaRepository;
+import tqs.project.api.services.BebidaService;
+
+@Service
+public class BebidaServiceImpl implements BebidaService{
+
+    private final BebidaRepository bebidaRepository;
+
+    public BebidaServiceImpl(BebidaRepository bebidaRepository){
+        this.bebidaRepository = bebidaRepository;
+    }
+
+    @Override
+    public Bebida getBebida(Long id) {
+        return bebidaRepository.findById(id).orElse(null);
+    }
+}

--- a/src/main/java/tqs/project/api/services/impl/CustomUserDetailsServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/CustomUserDetailsServiceImpl.java
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import tqs.project.api.models.Utilizador;
 import tqs.project.api.repositories.UtilizadorRepository;
-import tqs.project.api.services.UserService;
+import tqs.project.api.services.CustomUserDetailsService;
 
 @Service
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService {
+public class CustomUserDetailsServiceImpl implements CustomUserDetailsService {
     private final UtilizadorRepository utilizadorRepository;
 
     @Override

--- a/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
@@ -8,18 +8,24 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import tqs.project.api.models.Reserva;
+import tqs.project.api.models.Utilizador;
 import tqs.project.api.others.Restaurant;
 import tqs.project.api.repositories.ReservaRepository;
+import tqs.project.api.repositories.UtilizadorRepository;
 import tqs.project.api.services.ReservaService;
 
 @Service
 public class ReservaServiceImpl implements ReservaService{
     
     private final ReservaRepository reservaRepository;
+    private final UtilizadorRepository utilizadorRepository;
+    private final Restaurant restaurant = new Restaurant();
 
-    public ReservaServiceImpl(ReservaRepository reservaRepository){
+    public ReservaServiceImpl(ReservaRepository reservaRepository, UtilizadorRepository utilizadorRepository){
         this.reservaRepository = reservaRepository;
+        this.utilizadorRepository = utilizadorRepository;
     }
+
 
     @Override
     public List<LocalTime> getAvailableSlots(LocalDate date) {
@@ -45,5 +51,34 @@ public class ReservaServiceImpl implements ReservaService{
         availableSlots.removeAll(slotsToRemove);
 
         return availableSlots;
+    }
+
+    @Override
+    public Reserva createBooking(Reserva reserva){
+        List<Reserva> bookings = reservaRepository.findByDiaAndHora(reserva.getDia(), reserva.getHora());
+        int occupiedTables = 0;
+
+        for (Reserva booking : bookings) {
+            occupiedTables += booking.getQuantidadeMesas();
+        }
+
+        // Verify if there is space for customers
+        if (occupiedTables + reserva.getQuantidadeMesas() > restaurant.getTotalTables()){
+            return null;
+        }
+
+        Reserva saved = reservaRepository.save(reserva);
+
+        // add RESERVA to UTILIZADOR
+        Utilizador utilizador = utilizadorRepository.findById(reserva.getUtilizador().getId()).get();
+
+        if (utilizador.getReservas() == null){
+            utilizador.setReservas(new ArrayList<>());
+        }
+
+        utilizador.getReservas().add(reserva);
+        utilizadorRepository.save(utilizador);
+
+        return saved;
     }
 }

--- a/src/test/java/tqs/project/api/controllers/BebidaControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/BebidaControllerTest.java
@@ -1,0 +1,77 @@
+package tqs.project.api.controllers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import io.restassured.http.ContentType;
+import io.restassured.module.mockmvc.RestAssuredMockMvc;
+
+import tqs.project.api.configuration.JwtAuthenticationFilter;
+import tqs.project.api.models.Bebida;
+import tqs.project.api.services.BebidaService;
+
+@WebMvcTest(BebidaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class BebidaControllerTest {
+    
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    BebidaService service;
+
+    @MockBean
+    JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    Bebida beverage = new Bebida();
+
+    @BeforeEach
+    void setUp(){
+        beverage.setId(1L);
+        beverage.setNome("Fanta");
+    }
+
+    @Test
+    void givenBebida_whenGetBebidaById_thenReturnBebida(){
+        when(service.getBebida(1L)).thenReturn(beverage);
+
+        RestAssuredMockMvc
+            .given()
+                .mockMvc(mvc)
+                .contentType(ContentType.JSON)
+            .when()
+                .get("/api/beverages/1")
+            .then()
+                .statusCode(HttpStatus.SC_OK)
+                .assertThat()
+                .body("nome", equalTo("Fanta"));
+
+        verify(service, times(1)).getBebida(1L);
+    }
+
+    @Test 
+    void givenBebida_whenGetBebidaByWrongId_thenReturn404(){
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("/api/beverages/1")
+        .then()
+            .statusCode(HttpStatus.SC_NOT_FOUND);
+
+        verify(service, times(1)).getBebida(Mockito.any());
+    }
+}

--- a/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
@@ -48,6 +48,7 @@ class ReservaControllerTest {
     LocalDate day = LocalDate.parse("2024-01-01");
     Restaurant restaurant = new Restaurant();
     Reserva reserva = new Reserva();
+    Utilizador utilizador = new Utilizador();
 
     @BeforeEach
     void setUp(){
@@ -56,7 +57,6 @@ class ReservaControllerTest {
         reserva.setHora(LocalTime.now());
         reserva.setStatus(STATUS.PENDING.ordinal());
 
-        Utilizador utilizador = new Utilizador();
         utilizador.setEmail("user@gmail.com");
         utilizador.setPassword("password");
         utilizador.setRole(ROLES.USER);
@@ -97,6 +97,30 @@ class ReservaControllerTest {
                 .assertThat()
                 .body("utilizador.email", is("user@gmail.com"))
                 .body("status", is(STATUS.PENDING.ordinal()));
+
+        verify(service, times(1)).createBooking(Mockito.any());
+    }
+
+    @Test
+    void whenCreateInvalidBooking_thenReturnBadRequest() {
+        Reserva innerReserva = new Reserva();
+        innerReserva.setHora(LocalTime.now());
+        innerReserva.setDia(LocalDate.now());
+        innerReserva.setQuantidadeMesas(12);
+        innerReserva.setStatus(STATUS.PENDING.ordinal());
+        innerReserva.setUtilizador(utilizador);
+
+        when(service.createBooking(Mockito.any())).thenReturn(null);
+
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+            .body(innerReserva)
+        .when()
+            .post("/api/bookings")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
 
         verify(service, times(1)).createBooking(Mockito.any());
     }

--- a/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
@@ -6,10 +6,12 @@ import static org.mockito.Mockito.when;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -18,9 +20,15 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
+
 import tqs.project.api.configuration.JwtAuthenticationFilter;
+import tqs.project.api.models.Reserva;
+import tqs.project.api.models.Utilizador;
+import tqs.project.api.others.ROLES;
 import tqs.project.api.others.Restaurant;
+import tqs.project.api.others.STATUS;
 import tqs.project.api.services.ReservaService;
+import tqs.project.api.services.CustomUserDetailsService;
 
 @WebMvcTest(ReservaController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -34,11 +42,28 @@ class ReservaControllerTest {
     @MockBean
     JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @MockBean
+    CustomUserDetailsService userService;
+
     LocalDate day = LocalDate.parse("2024-01-01");
     Restaurant restaurant = new Restaurant();
+    Reserva reserva = new Reserva();
 
     @BeforeEach
     void setUp(){
+        reserva.setQuantidadeMesas(1);
+        reserva.setDia(LocalDate.now());
+        reserva.setHora(LocalTime.now());
+        reserva.setStatus(STATUS.PENDING.ordinal());
+
+        Utilizador utilizador = new Utilizador();
+        utilizador.setEmail("user@gmail.com");
+        utilizador.setPassword("password");
+        utilizador.setRole(ROLES.USER);
+
+        reserva.setUtilizador(utilizador);
+
+        when(service.createBooking(Mockito.any())).thenReturn(reserva);
         when(service.getAvailableSlots(day)).thenReturn(restaurant.getDailySlots());
     }
 
@@ -56,5 +81,23 @@ class ReservaControllerTest {
                 .body("size()", is(restaurant.getDailySlots().size()));
         
         verify(service, times(1)).getAvailableSlots(day);
+    }
+
+    @Test
+    void whenCreateBooking_thenReturnCreatedBooking() {
+        RestAssuredMockMvc
+            .given()
+                .mockMvc(mvc)
+                .contentType(ContentType.JSON)
+                .body(reserva)
+            .when()
+                .post("/api/bookings")
+            .then()
+                .statusCode(HttpStatus.SC_CREATED)
+                .assertThat()
+                .body("utilizador.email", is("user@gmail.com"))
+                .body("status", is(STATUS.PENDING.ordinal()));
+
+        verify(service, times(1)).createBooking(Mockito.any());
     }
 }

--- a/src/test/java/tqs/project/api/repositories/BebidaRepositoryTest.java
+++ b/src/test/java/tqs/project/api/repositories/BebidaRepositoryTest.java
@@ -1,0 +1,47 @@
+package tqs.project.api.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import tqs.project.api.models.Bebida;
+
+@DataJpaTest
+class BebidaRepositoryTest {
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private BebidaRepository repository;
+
+    Bebida beverage = new Bebida();
+
+    @BeforeEach
+    void setUp(){
+        beverage.setNome("Fanta");
+        beverage.setPreco(2.5);
+        beverage.setStock(10);
+
+        entityManager.persistAndFlush(beverage);
+    }
+
+    @Test
+    void givenBebida_whenFindBebidaById_thenReturnBebida(){
+        Bebida found = repository.findById(beverage.getId()).get();
+        
+        assertThat(found.getNome()).isEqualTo("Fanta");
+    }
+
+    @Test
+    void givenBebida_whenFindBebidaByWrongId_thenReturnNull(){
+        Optional<Bebida> found = repository.findById(300L);
+        
+        assertThat(found).isEmpty();
+    }
+}

--- a/src/test/java/tqs/project/api/services/BebidaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/BebidaServiceTest.java
@@ -1,0 +1,59 @@
+package tqs.project.api.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tqs.project.api.models.Bebida;
+import tqs.project.api.repositories.BebidaRepository;
+import tqs.project.api.services.impl.BebidaServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+public class BebidaServiceTest {
+    
+    @Mock(strictness = Mock.Strictness.LENIENT )
+    BebidaRepository repository;
+
+    @InjectMocks
+    private BebidaServiceImpl service;
+
+    Bebida beverage = new Bebida();
+
+    @BeforeEach
+    void setUp(){
+        beverage.setId(1L);
+        beverage.setNome("Fanta");
+        beverage.setPreco(2.5);
+        beverage.setStock(10);
+
+        when(repository.findById(1L)).thenReturn(Optional.of(beverage));
+    }
+
+    @Test
+    void whenGetBebidaById_thenReturnBebida() {
+        Bebida found = service.getBebida(beverage.getId()); 
+        
+        verify(repository, times(1)).findById(Mockito.any());
+        assertThat(found.getNome()).isEqualTo("Fanta");
+    }
+
+    @Test
+    void whenGetBebidaByWrongId_thenReturnNull() {
+        Bebida found = service.getBebida(300L); 
+        
+        verify(repository, times(1)).findById(Mockito.any());
+        assertThat(found).isNull();
+    }
+}

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -1,6 +1,7 @@
 package tqs.project.api.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -25,12 +27,16 @@ import tqs.project.api.others.STATUS;
 import tqs.project.api.models.Reserva;
 import tqs.project.api.models.Utilizador;
 import tqs.project.api.repositories.ReservaRepository;
+import tqs.project.api.repositories.UtilizadorRepository;
 import tqs.project.api.services.impl.ReservaServiceImpl;
 
 @ExtendWith(MockitoExtension.class)
 class ReservaServiceTest {
     @Mock(strictness = Mock.Strictness.LENIENT )
-    ReservaRepository repository;
+    ReservaRepository reservaRepository;
+
+    @Mock(strictness = Mock.Strictness.LENIENT )
+    UtilizadorRepository utilizadorRepository;
 
     @InjectMocks
     ReservaServiceImpl service;
@@ -38,18 +44,18 @@ class ReservaServiceTest {
     Restaurant restaurant = new Restaurant();
     LocalDate day = LocalDate.parse("2024-01-01");
     LocalDate day2 = LocalDate.parse("2024-01-02");
+    Utilizador utilizador = new Utilizador();
+    Utilizador utilizador2 = new Utilizador();
 
     @BeforeEach
     void setUp(){
         List<Reserva> noBookings = new ArrayList<>();
-        when(repository.findByDia(day)).thenReturn(noBookings);
+        when(reservaRepository.findByDia(day)).thenReturn(noBookings);
 
-        Utilizador utilizador = new Utilizador();
         utilizador.setEmail("nice-email@gmail.com");
         utilizador.setPassword("123123123");
         utilizador.setRole(ROLES.USER);
 
-        Utilizador utilizador2 = new Utilizador();
         utilizador2.setEmail("nolimits88@live.com.pt");
         utilizador2.setPassword("0987654321");
         utilizador2.setRole(ROLES.USER);
@@ -69,7 +75,7 @@ class ReservaServiceTest {
         reserva2.setHora(LocalTime.of(12,00));
 
         List<Reserva> someBookings = Arrays.asList(reserva, reserva2);
-        when(repository.findByDia(day2)).thenReturn(someBookings);
+        when(reservaRepository.findByDia(day2)).thenReturn(someBookings);
     }
 
     @Test
@@ -77,7 +83,7 @@ class ReservaServiceTest {
         List<LocalTime> availableSlots = service.getAvailableSlots(day);
 
         assertThat(availableSlots).hasSize(restaurant.getDailySlots().size());
-        verify(repository, times(1)).findByDia(Mockito.any());
+        verify(reservaRepository, times(1)).findByDia(Mockito.any());
     }
 
     @Test
@@ -88,6 +94,44 @@ class ReservaServiceTest {
             .hasSize(restaurant.getDailySlots().size() - 1)
             .doesNotContain(LocalTime.of(11,00));
 
-        verify(repository, times(1)).findByDia(Mockito.any());
+        verify(reservaRepository, times(1)).findByDia(Mockito.any());
+    }
+
+    @Test
+    void givenReserva_whenCreateReserva_thenReturnReserva(){
+        Reserva innerReserva = new Reserva();
+        innerReserva.setHora(LocalTime.now());
+        innerReserva.setDia(LocalDate.now());
+        innerReserva.setQuantidadeMesas(5);
+        innerReserva.setStatus(STATUS.PENDING.ordinal());
+        innerReserva.setUtilizador(utilizador);
+
+
+        when(utilizadorRepository.findById(Mockito.any())).thenReturn(Optional.of(utilizador));
+        when(reservaRepository.save(innerReserva)).thenReturn(innerReserva);
+
+        Reserva found = service.createBooking(innerReserva);
+
+        assertThat(found).isEqualTo(innerReserva);
+        verify(reservaRepository, times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void givenReservaWithTooManyPeople_whenCreateReserva_thenReturnNull(){
+        Reserva innerReserva = new Reserva();
+        innerReserva.setHora(LocalTime.now());
+        innerReserva.setDia(LocalDate.now());
+        innerReserva.setQuantidadeMesas(12);
+        innerReserva.setStatus(STATUS.PENDING.ordinal());
+        innerReserva.setUtilizador(utilizador);
+
+
+        when(utilizadorRepository.findById(Mockito.any())).thenReturn(Optional.of(utilizador));
+        when(reservaRepository.save(innerReserva)).thenReturn(innerReserva);
+
+        Reserva found = service.createBooking(innerReserva);
+
+        assertThat(found).isNull();
+        verify(reservaRepository, never()).save(Mockito.any());
     }
 }

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -113,6 +113,7 @@ class ReservaServiceTest {
 
         Reserva found = service.createBooking(innerReserva);
 
+        assertThat(utilizador.getReservas()).isNotNull();
         assertThat(found).isEqualTo(innerReserva);
         verify(reservaRepository, times(1)).save(Mockito.any());
     }

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -55,6 +55,7 @@ class ReservaServiceTest {
         utilizador.setEmail("nice-email@gmail.com");
         utilizador.setPassword("123123123");
         utilizador.setRole(ROLES.USER);
+        utilizador.setReservas(null);
 
         utilizador2.setEmail("nolimits88@live.com.pt");
         utilizador2.setPassword("0987654321");


### PR DESCRIPTION
### Issue

Closes [Endpoint para obter bebidas para menu](https://tqsprojectrestaurant.atlassian.net/jira/software/projects/RMO/issues/RMO-85)

### Reason for this change

It currently requires us to fetch both dishes and beverages whenever we try to fetch our daily menu; There was no way of getting this information so this aims to fix that.

### Description of changes

- Created `BebidaController` and `BebidaService`;
- Created tests for `Bebida` related classes;
- Added logic to `Bebida` related classes.

### Description of how you validated changes

Tested with `mvn test` and `docker-compose up`

### Checklist
- [X] I have tested my changes locally.

### Aditional Information
N/A