### PR TITLE
[Reserva] : fix booking table error, add endpoint to update booking

### DIFF
--- a/src/main/java/tqs/project/api/configuration/SecurityConfig.java
+++ b/src/main/java/tqs/project/api/configuration/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
                 .requestMatchers("api/requests/**").hasAnyRole(ROLES.KITCHEN.toString(),  ROLES.WAITER.toString())
                 .requestMatchers("api/bookings").hasAnyRole(ROLES.KITCHEN.toString(),  ROLES.WAITER.toString(), ROLES.USER.toString())
                 .requestMatchers("api/bookings/pending").hasRole(ROLES.WAITER.toString())
+                .requestMatchers("api/bookings/confirm/**").hasRole(ROLES.WAITER.toString())
+                .requestMatchers("api/bookings/cancel/**").hasRole(ROLES.WAITER.toString())
                 .anyRequest().permitAll()
             )
             .sessionManagement(manager -> manager.sessionCreationPolicy(STATELESS))

--- a/src/main/java/tqs/project/api/controllers/ReservaController.java
+++ b/src/main/java/tqs/project/api/controllers/ReservaController.java
@@ -10,7 +10,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -100,7 +102,7 @@ public class ReservaController {
     @Operation(summary = "Get all pending bookings", description = "Returns list with all pending bookings")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
-        @ApiResponse(responseCode = "403", description = "No access has been granted to access this")
+        @ApiResponse(responseCode = "400", description = "Failed to get authenticated user")
     })
     @GetMapping("/pending")
     public ResponseEntity<List<Reserva>> getPendingBookings(){
@@ -113,5 +115,41 @@ public class ReservaController {
         List<Reserva> pendingBookings = reservaService.getPendingBookings();
 
         return new ResponseEntity<>(pendingBookings, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Confirm booking", description = "Returns updated booking")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+        @ApiResponse(responseCode = "400", description = "Failed to get authenticated user")
+    })
+    @PutMapping("/confirm/{id}")
+    public ResponseEntity<Reserva> confirmBooking(@PathVariable("id") Long id){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+        if (authentication == null){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        Reserva updatedBooking = reservaService.confirmBooking(id);
+
+        return new ResponseEntity<>(updatedBooking, HttpStatus.OK);
+    }
+
+    @Operation(summary = "Cancel booking", description = "Returns updated booking")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved"),
+        @ApiResponse(responseCode = "400", description = "Failed to get authenticated user")
+    })
+    @PutMapping("/cancel/{id}")
+    public ResponseEntity<Reserva> cancelBooking(@PathVariable("id") Long id){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+        if (authentication == null){
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+
+        Reserva updatedBooking = reservaService.cancelBooking(id);
+
+        return new ResponseEntity<>(updatedBooking, HttpStatus.OK);
     }
 }

--- a/src/main/java/tqs/project/api/services/ReservaService.java
+++ b/src/main/java/tqs/project/api/services/ReservaService.java
@@ -15,4 +15,8 @@ public interface ReservaService {
     List<Reserva> getUserBookings(String email);
 
     List<Reserva> getPendingBookings();
+
+    Reserva confirmBooking(Long id);
+
+    Reserva cancelBooking(Long id);
 }

--- a/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
+++ b/src/main/java/tqs/project/api/services/impl/ReservaServiceImpl.java
@@ -48,6 +48,7 @@ public class ReservaServiceImpl implements ReservaService{
             if (usedTables == restaurant.getTotalTables()){
                 slotsToRemove.add(hour);
             }
+            usedTables = 0;
         }
 
         availableSlots.removeAll(slotsToRemove);
@@ -103,5 +104,32 @@ public class ReservaServiceImpl implements ReservaService{
     @Override
     public List<Reserva> getPendingBookings() {
         return reservaRepository.findAllByStatus(STATUS.PENDING.ordinal());
+    }
+
+    @Override
+    public Reserva confirmBooking(Long id) {
+        Reserva updatedReserva = reservaRepository.findById(id).orElse(null);
+
+        if (updatedReserva == null){
+            return null;
+        }
+
+        updatedReserva.setStatus(STATUS.COMPLETED.ordinal());
+
+        return reservaRepository.save(updatedReserva);
+    }
+
+
+    @Override
+    public Reserva cancelBooking(Long id) {
+        Reserva updatedReserva = reservaRepository.findById(id).orElse(null);
+
+        if (updatedReserva == null){
+            return null;
+        }
+
+        updatedReserva.setStatus(STATUS.CANCELLED.ordinal());
+
+        return reservaRepository.save(updatedReserva);
     }
 }

--- a/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
@@ -218,4 +218,55 @@ class ReservaControllerTest {
 
         verify(service, times(1)).getPendingBookings();
     }
+
+    @Test
+    @WithMockUser(roles = "WAITER")
+    void whenConfirmBooking_thenReturnUpdatedBooking(){
+        Reserva completedBooking = new Reserva();
+        completedBooking.setQuantidadeMesas(1);
+        completedBooking.setDia(LocalDate.now());
+        completedBooking.setHora(LocalTime.now());
+        completedBooking.setStatus(STATUS.COMPLETED.ordinal());
+
+        when(service.confirmBooking(Mockito.any())).thenReturn(completedBooking);
+
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .put("/api/bookings/confirm/1")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .assertThat()
+            .body("status", is(STATUS.COMPLETED.ordinal()));
+
+        verify(service, times(1)).confirmBooking(Mockito.any());
+    }
+
+
+    @Test
+    @WithMockUser(roles = "WAITER")
+    void whenCancelBooking_thenReturnUpdatedBooking(){
+        Reserva cancelledBooking = new Reserva();
+        cancelledBooking.setQuantidadeMesas(1);
+        cancelledBooking.setDia(LocalDate.now());
+        cancelledBooking.setHora(LocalTime.now());
+        cancelledBooking.setStatus(STATUS.CANCELLED.ordinal());
+
+        when(service.confirmBooking(Mockito.any())).thenReturn(cancelledBooking);
+
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .put("/api/bookings/confirm/1")
+        .then()
+            .statusCode(HttpStatus.SC_OK)
+            .assertThat()
+            .body("status", is(STATUS.CANCELLED.ordinal()));
+
+        verify(service, times(1)).confirmBooking(Mockito.any());
+    }
 }

--- a/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
@@ -254,19 +254,19 @@ class ReservaControllerTest {
         cancelledBooking.setHora(LocalTime.now());
         cancelledBooking.setStatus(STATUS.CANCELLED.ordinal());
 
-        when(service.confirmBooking(Mockito.any())).thenReturn(cancelledBooking);
+        when(service.cancelBooking(Mockito.any())).thenReturn(cancelledBooking);
 
         RestAssuredMockMvc
         .given()
             .mockMvc(mvc)
             .contentType(ContentType.JSON)
         .when()
-            .put("/api/bookings/confirm/1")
+            .put("/api/bookings/cancel/1")
         .then()
             .statusCode(HttpStatus.SC_OK)
             .assertThat()
             .body("status", is(STATUS.CANCELLED.ordinal()));
 
-        verify(service, times(1)).confirmBooking(Mockito.any());
+        verify(service, times(1)).cancelBooking(Mockito.any());
     }
 }

--- a/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
+++ b/src/test/java/tqs/project/api/controllers/ReservaControllerTest.java
@@ -220,6 +220,20 @@ class ReservaControllerTest {
     }
 
     @Test
+    void whenGetPendingBookingsWithoutAuthentication_thenReturnBadRequest(){
+        when(securityContext.getAuthentication()).thenReturn(null);
+
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .get("/api/bookings/pending")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    @Test
     @WithMockUser(roles = "WAITER")
     void whenConfirmBooking_thenReturnUpdatedBooking(){
         Reserva completedBooking = new Reserva();
@@ -242,6 +256,20 @@ class ReservaControllerTest {
             .body("status", is(STATUS.COMPLETED.ordinal()));
 
         verify(service, times(1)).confirmBooking(Mockito.any());
+    }
+
+    @Test
+    void whenPutConfirmBookingWithoutAuthentication_thenReturnBadRequest(){
+        when(securityContext.getAuthentication()).thenReturn(null);
+
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .put("/api/bookings/confirm/1")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
 
@@ -268,5 +296,19 @@ class ReservaControllerTest {
             .body("status", is(STATUS.CANCELLED.ordinal()));
 
         verify(service, times(1)).cancelBooking(Mockito.any());
+    }
+
+    @Test
+    void whenPutCancelBookingWithoutAuthentication_thenReturnBadRequest(){
+        when(securityContext.getAuthentication()).thenReturn(null);
+
+        RestAssuredMockMvc
+        .given()
+            .mockMvc(mvc)
+            .contentType(ContentType.JSON)
+        .when()
+            .put("/api/bookings/cancel/1")
+        .then()
+            .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 }

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -164,4 +164,44 @@ class ReservaServiceTest {
         assertThat(bookings).hasSize(1);
         verify(reservaRepository, times(1)).findAllByStatus(STATUS.PENDING.ordinal());
     }
+
+    @Test
+    void givenBookingToUpdate_whenConfirmBooking_thenReturnUpdatedBooking() {
+        Reserva reservaToUpdate = new Reserva();
+        reservaToUpdate.setQuantidadeMesas(5);
+        reservaToUpdate.setStatus(STATUS.PENDING.ordinal());
+        reservaToUpdate.setDia(day);
+        reservaToUpdate.setHora(LocalTime.of(11,00));
+
+        when(reservaRepository.findById(1L)).thenReturn(Optional.of(reservaToUpdate));
+        when(reservaRepository.save(Mockito.any())).thenReturn(reserva);
+        
+        Reserva updatedReserva = service.confirmBooking(1L);
+
+        assertThat(updatedReserva.getStatus()).isEqualTo(STATUS.COMPLETED.ordinal());
+        verify(reservaRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void givenBookingToUpdate_whenCancelBooking_thenReturnUpdatedBooking() {
+        Reserva reservaToUpdate = new Reserva();
+        reservaToUpdate.setQuantidadeMesas(5);
+        reservaToUpdate.setStatus(STATUS.PENDING.ordinal());
+        reservaToUpdate.setDia(day);
+        reservaToUpdate.setHora(LocalTime.of(11,00));
+
+        Reserva reservaCancelled = new Reserva();
+        reservaCancelled.setQuantidadeMesas(5);
+        reservaCancelled.setStatus(STATUS.CANCELLED.ordinal());
+        reservaCancelled.setDia(day);
+        reservaCancelled.setHora(LocalTime.of(11,00));
+
+        when(reservaRepository.findById(1L)).thenReturn(Optional.of(reservaToUpdate));
+        when(reservaRepository.save(Mockito.any())).thenReturn(reservaCancelled);
+        
+        Reserva updatedReserva = service.cancelBooking(1L);
+
+        assertThat(updatedReserva.getStatus()).isEqualTo(STATUS.CANCELLED.ordinal());
+        verify(reservaRepository, times(1)).findById(1L);
+    }
 }

--- a/src/test/java/tqs/project/api/services/ReservaServiceTest.java
+++ b/src/test/java/tqs/project/api/services/ReservaServiceTest.java
@@ -183,6 +183,14 @@ class ReservaServiceTest {
     }
 
     @Test
+    void givenInvalidBookingIdToUpdate_whenConfirmBooking_thenReturnNull() {
+        Reserva found = service.confirmBooking(1L);
+
+        assertThat(found).isNull();
+        verify(reservaRepository, times(1)).findById(Mockito.any());
+    }
+
+    @Test
     void givenBookingToUpdate_whenCancelBooking_thenReturnUpdatedBooking() {
         Reserva reservaToUpdate = new Reserva();
         reservaToUpdate.setQuantidadeMesas(5);
@@ -203,5 +211,13 @@ class ReservaServiceTest {
 
         assertThat(updatedReserva.getStatus()).isEqualTo(STATUS.CANCELLED.ordinal());
         verify(reservaRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void givenInvalidBookingIdToUpdate_whenCancelBooking_thenReturnNull() {
+        Reserva found = service.cancelBooking(1L);
+
+        assertThat(found).isNull();
+        verify(reservaRepository, times(1)).findById(Mockito.any());
     }
 }


### PR DESCRIPTION
### Issue

Closes #<issue number here>.

### Reason for this change

We need our waiter to be capable of updating bookings, accepting or refusing them.

### Description of changes

- Fixed error with booking table calculation;
- Added logic for update booking endpoint;
- Added tests.

### Description of how you validated changes

Tested with `mvn test` and `docker-compose up`

### Checklist
- [X] I have tested my changes locally.

### Aditional Information
N/A